### PR TITLE
Update drv_gpio.c

### DIFF
--- a/libraries/HAL_Drivers/drv_gpio.c
+++ b/libraries/HAL_Drivers/drv_gpio.c
@@ -276,7 +276,7 @@ static rt_err_t ifx_pin_irq_enable(struct rt_device *device, rt_base_t pin,
         irqmap = &pin_irq_map[gpio_port];
 
 #if !defined(COMPONENT_CAT1C)
-        IRQn_Type irqn = (IRQn_Type)(irqmap->irqno + PORT_GET(irqmap->port));
+        IRQn_Type irqn = irqmap->irqno;
 #endif
         irq_cb_data[irqn].callback = irq_callback;
         irq_cb_data[irqn].callback_arg = (rt_uint16_t *)&pin_irq_map[gpio_port].port;
@@ -313,7 +313,7 @@ static rt_err_t ifx_pin_irq_enable(struct rt_device *device, rt_base_t pin,
 
         irqmap = &pin_irq_map[gpio_port];
 #if !defined(COMPONENT_CAT1C)
-        IRQn_Type irqn = (IRQn_Type)(irqmap->irqno + PORT_GET(irqmap->port));
+        IRQn_Type irqn = irqmap->irqno;
 #endif
         _cyhal_irq_disable(irqn);
 

--- a/libraries/HAL_Drivers/drv_gpio.c
+++ b/libraries/HAL_Drivers/drv_gpio.c
@@ -7,6 +7,7 @@
  * Date           Author            Notes
  * 2022-07-1      Rbb666            first version
  * 2023-05-25	  Rbb666            fix pin irq problem
+ * 2025-04-24     Passionate0424    fix ifx_pin_irq_enable
  */
 
 #include "drv_gpio.h"
@@ -310,8 +311,7 @@ static rt_err_t ifx_pin_irq_enable(struct rt_device *device, rt_base_t pin,
     {
         level = rt_hw_interrupt_disable();
 
-        Cy_GPIO_Port_Deinit(CYHAL_GET_PORTADDR(gpio_pin));
-
+        irqmap = &pin_irq_map[gpio_port];
 #if !defined(COMPONENT_CAT1C)
         IRQn_Type irqn = (IRQn_Type)(irqmap->irqno + PORT_GET(irqmap->port));
 #endif


### PR DESCRIPTION
英飞凌drv_gpio.c中的ifx_pin_irq_enable中，当enabled = PIN_IRQ_DISABLE情况下，irqmap未赋值导致程序进入hardfault，同时Cy_GPIO_Port_Deinit(CYHAL_GET_PORTADDR(gpio_pin));我认为是无必要的，关中断原有的引脚配置不应被改变。同时修改中断号不正确问题