### PR TITLE
修改ifx_configure

### DIFF
--- a/libraries/HAL_Drivers/drv_soft_i2c.c
+++ b/libraries/HAL_Drivers/drv_soft_i2c.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
- * Date           Author       Notes
- * 2022-07-20     Rbb666       first version
+ * Date           Author         Notes
+ * 2022-07-20     Rbb666         first version
+ * 2025-05-30     Passionate0424 Rename the initialization function
  */
 
 #include <board.h>
@@ -152,7 +153,7 @@ static rt_err_t ifx_i2c_bus_unlock(const struct ifx_soft_i2c_config *cfg)
 }
 
 /* I2C initialization function */
-int rt_hw_i2c_init(void)
+int rt_hw_soft_i2c_init(void)
 {
     rt_size_t obj_num = sizeof(i2c_obj) / sizeof(struct ifx_i2c);
     rt_err_t result;
@@ -175,6 +176,6 @@ int rt_hw_i2c_init(void)
 
     return RT_EOK;
 }
-INIT_BOARD_EXPORT(rt_hw_i2c_init);
+INIT_BOARD_EXPORT(rt_hw_soft_i2c_init);
 
 #endif /* RT_USING_I2C */

--- a/libraries/HAL_Drivers/drv_uart.c
+++ b/libraries/HAL_Drivers/drv_uart.c
@@ -217,7 +217,7 @@ static rt_err_t ifx_control(struct rt_serial_device *serial, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        ifx_control
+        NVIC_DisableIRQ(uart->config->UART_SCB_IRQ_cfg->intrSrc);
         break;
 
     case RT_DEVICE_CTRL_SET_INT:

--- a/libraries/HAL_Drivers/drv_uart.c
+++ b/libraries/HAL_Drivers/drv_uart.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
- * Date           Author       Notes
- * 2022-06-29     Rbb666       first version
+ * Date           Author          Notes
+ * 2022-06-29     Rbb666          first version
+ * 2025-05-11     Passionate0424  fix ifx_configure
  */
 
 #include <rtthread.h>
@@ -181,7 +182,6 @@ static rt_err_t ifx_configure(struct rt_serial_device *serial, struct serial_con
     RT_ASSERT(serial != RT_NULL);
     struct ifx_uart *uart = (struct ifx_uart *) serial->parent.user_data;
     RT_ASSERT(uart != RT_NULL);
-    static uint8_t init_flag = 0;
 
     cy_en_scb_uart_status_t result = CY_RSLT_SUCCESS;
 
@@ -195,13 +195,11 @@ static rt_err_t ifx_configure(struct rt_serial_device *serial, struct serial_con
     };
 
     /* Initialize retarget-io to use the debug UART port */
-    if (!init_flag)
-        result = cyhal_uart_init(uart->config->uart_obj, uart->config->tx_pin, uart->config->rx_pin, NC, NC, NULL, &uart_config);
+    result = cyhal_uart_init(uart->config->uart_obj, uart->config->tx_pin, uart->config->rx_pin, NC, NC, NULL, &uart_config);
 
     if (result == CY_RSLT_SUCCESS)
     {
         result = cyhal_uart_set_baud(uart->config->uart_obj, cfg->baud_rate, NULL);
-        init_flag = 1;
     }
 
     RT_ASSERT(result == RT_EOK);

--- a/libraries/HAL_Drivers/drv_uart.c
+++ b/libraries/HAL_Drivers/drv_uart.c
@@ -7,6 +7,7 @@
  * Date           Author          Notes
  * 2022-06-29     Rbb666          first version
  * 2025-05-11     Passionate0424  fix ifx_configure
+ * 2025-05-12     Passionate0424  update ifx_control
  */
 
 #include <rtthread.h>
@@ -216,7 +217,7 @@ static rt_err_t ifx_control(struct rt_serial_device *serial, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-
+        ifx_control
         break;
 
     case RT_DEVICE_CTRL_SET_INT:


### PR DESCRIPTION
1.静态变量init_flag，一旦有串口初始化就被置1，所以使用多个串口时，后续打开其他串口调用ifx_configure就不调用cyhal_uart_init，出现问题
2.ifx_control增加关中断